### PR TITLE
fix: matrix cache silently corrupts matrices when view/sensor/surface names collide

### DIFF
--- a/frads/methods.py
+++ b/frads/methods.py
@@ -531,6 +531,50 @@ class WorkflowConfig:
         return WorkflowConfig(settings, model)
 
 
+MATRIX_CACHE_SCHEMA_VERSION = 2
+
+
+def _matrix_cache_prefixes(mdata, mfile, *name_groups) -> tuple[str, str, str]:
+    """Return the (view, sensor, surface) key prefixes for a matrix cache.
+
+    Schema v2 cache files namespace per-entity keys as ``view_{name}_...``,
+    ``sensor_{name}_...`` and ``surface_{name}_...``. Legacy (v1) files used
+    the bare entity name for every group, so a view and a sensor (or surface)
+    sharing a name were saved under the same key -- the later group silently
+    overwrote the earlier one and load_matrices restored a corrupted matrix
+    without any error. Legacy files are therefore only accepted when no names
+    collide across groups.
+
+    Args:
+        mdata: The mapping loaded from the ``.npz`` cache file.
+        mfile: Path of the cache file, used in the error message.
+        name_groups: One iterable of entity names per group (views, sensors,
+            surfaces, ...) stored in the cache.
+
+    Returns:
+        The ("view_", "sensor_", "surface_") prefixes for schema v2 files,
+        or three empty strings for a collision-free legacy file.
+
+    Raises:
+        ValueError: If the file is a legacy cache and entity names collide
+            across groups (the cached arrays are corrupted).
+    """
+    if "_schema_version" in mdata:
+        return "view_", "sensor_", "surface_"
+    seen: set = set()
+    for group in name_groups:
+        colliding = seen.intersection(group)
+        if colliding:
+            raise ValueError(
+                f"Matrix cache {mfile} predates key namespacing and contains "
+                f"colliding entity names {sorted(colliding)}: the cached "
+                "arrays were silently overwritten on save and are corrupted. "
+                "Delete the file or set settings.overwrite to regenerate."
+            )
+        seen.update(group)
+    return "", "", ""
+
+
 class PhaseMethod:
     """Base class for phase methods.
 
@@ -876,10 +920,13 @@ class TwoPhaseMethod(PhaseMethod):
         if not self.mfile.exists():
             raise FileNotFoundError("Matrices file not found")
         mdata = np.load(self.mfile)
+        vp, sp, _ = _matrix_cache_prefixes(
+            mdata, self.mfile, self.view_sky_matrices, self.sensor_sky_matrices
+        )
         for view, mtx in self.view_sky_matrices.items():
-            mtx.array = mdata[f"{view}_sky_matrix"]
+            mtx.array = mdata[f"{vp}{view}_sky_matrix"]
         for sensor, mtx in self.sensor_sky_matrices.items():
-            mtx.array = mdata[f"{sensor}_sky_matrix"]
+            mtx.array = mdata[f"{sp}{sensor}_sky_matrix"]
 
     def calculate_view(
         self, view: str, time: datetime, dni: float, dhi: float
@@ -977,11 +1024,11 @@ class TwoPhaseMethod(PhaseMethod):
         """Save matrices to a .npz file in the Matrices directory.
         File name is the hash string of the configuration.
         """
-        matrices = {}
+        matrices = {"_schema_version": np.int64(MATRIX_CACHE_SCHEMA_VERSION)}
         for view, mtx in self.view_sky_matrices.items():
-            matrices[f"{view}_sky_matrix"] = mtx.array
+            matrices[f"view_{view}_sky_matrix"] = mtx.array
         for sensor, mtx in self.sensor_sky_matrices.items():
-            matrices[f"{sensor}_sky_matrix"] = mtx.array
+            matrices[f"sensor_{sensor}_sky_matrix"] = mtx.array
         np.savez(self.mtxdir / self.config.hash_str, **matrices)
 
 
@@ -1095,13 +1142,20 @@ class ThreePhaseMethod(PhaseMethod):
         """Load matrices from a .npz file in the Matrices directory."""
         logger.info(f"Loading matrices from {self.mfile}")
         mdata = np.load(self.mfile)
+        vp, sp, fp = _matrix_cache_prefixes(
+            mdata,
+            self.mfile,
+            self.view_window_matrices,
+            self.sensor_window_matrices,
+            self.surface_window_matrices,
+        )
         for view, mtx in self.view_window_matrices.items():
-            if (key := f"{view}_window_matrix") in mdata:
+            if (key := f"{vp}{view}_window_matrix") in mdata:
                 mtx.array = mdata[key]
         for sensor, mtx in self.sensor_window_matrices.items():
-            mtx.array = mdata[f"{sensor}_window_matrix"]
+            mtx.array = mdata[f"{sp}{sensor}_window_matrix"]
         for surface, mtx in self.surface_window_matrices.items():
-            mtx.array = mdata[f"{surface}_window_matrix"]
+            mtx.array = mdata[f"{fp}{surface}_window_matrix"]
         for name, mtx in self.daylight_matrices.items():
             mtx.array = mdata[f"{name}_daylight_matrix"]
 
@@ -1401,16 +1455,20 @@ class ThreePhaseMethod(PhaseMethod):
         """Saves the view window matrices, sensor window matrices, and daylight matrices
         to a NumPy `.npz` file.
 
-        The matrices are saved with keys formed by concatenating the corresponding
-        view, sensor, or window name with '_window_matrix' or '_daylight_matrix'.
+        Window matrices are saved under group-namespaced keys
+        ('view_{name}_window_matrix', 'sensor_{name}_window_matrix',
+        'surface_{name}_window_matrix') so that a view, sensor, or surface
+        sharing the same name cannot overwrite each other; daylight matrices
+        use '{window}_daylight_matrix'. The file carries a '_schema_version'
+        entry (currently 2) that load_matrices uses to detect legacy files.
         """
-        matrices = {}
+        matrices = {"_schema_version": np.int64(MATRIX_CACHE_SCHEMA_VERSION)}
         for view, mtx in self.view_window_matrices.items():
-            matrices[f"{view}_window_matrix"] = mtx.array
+            matrices[f"view_{view}_window_matrix"] = mtx.array
         for sensor, mtx in self.sensor_window_matrices.items():
-            matrices[f"{sensor}_window_matrix"] = mtx.array
+            matrices[f"sensor_{sensor}_window_matrix"] = mtx.array
         for surface, mtx in self.surface_window_matrices.items():
-            matrices[f"{surface}_window_matrix"] = mtx.array
+            matrices[f"surface_{surface}_window_matrix"] = mtx.array
         for window, mtx in self.daylight_matrices.items():
             matrices[f"{window}_daylight_matrix"] = mtx.array
         np.savez(self.mfile, **matrices)
@@ -1700,24 +1758,30 @@ class FivePhaseMethod(PhaseMethod):
         """ """
         logger.info(f"Loading matrices from {self.mfile}")
         mdata = np.load(self.mfile, allow_pickle=True)
+        vp, sp, _ = _matrix_cache_prefixes(
+            mdata,
+            self.mfile,
+            self.view_window_matrices,
+            self.sensor_window_matrices,
+        )
         for view, mtx in self.view_window_matrices.items():
-            mtx.array = mdata[f"{view}_window_matrix"]
+            mtx.array = mdata[f"{vp}{view}_window_matrix"]
         for sensor, mtx in self.sensor_window_matrices.items():
-            mtx.array = mdata[f"{sensor}_window_matrix"]
+            mtx.array = mdata[f"{sp}{sensor}_window_matrix"]
         for window, mtx in self.daylight_matrices.items():
             mtx.array = mdata[f"{window}_daylight_matrix"]
         for view, mtx in self.view_window_direct_matrices.items():
-            mtx.array = mdata[f"{view}_window_direct_matrix"]
+            mtx.array = mdata[f"{vp}{view}_window_direct_matrix"]
         for sensor, mtx in self.sensor_window_direct_matrices.items():
-            mtx.array = mdata[f"{sensor}_window_direct_matrix"]
+            mtx.array = mdata[f"{sp}{sensor}_window_direct_matrix"]
         for window, mtx in self.daylight_direct_matrices.items():
             mtx.array = mdata[f"{window}_daylight_direct_matrix"]
         for sensor, mtx in self.sensor_sun_direct_matrices.items():
-            mtx.array = mdata[f"{sensor}_sun_direct_matrix"]
+            mtx.array = mdata[f"{sp}{sensor}_sun_direct_matrix"]
         for view, mtx in self.view_sun_direct_matrices.items():
-            mtx.array = mdata[f"{view}_sun_direct_matrix"]
+            mtx.array = mdata[f"{vp}{view}_sun_direct_matrix"]
         for view, mtx in self.view_sun_direct_illuminance_matrices.items():
-            mtx.array = mdata[f"{view}_sun_direct_illuminance_matrix"]
+            mtx.array = mdata[f"{vp}{view}_sun_direct_illuminance_matrix"]
 
     def calculate_view_from_wea(self, view: str):
         logger.info("Step 1/2: Generating sky matrix from wea")
@@ -1815,25 +1879,25 @@ class FivePhaseMethod(PhaseMethod):
         return res3 - res3d + rescd
 
     def save_matrices(self):
-        matrices = {}
+        matrices = {"_schema_version": np.int64(MATRIX_CACHE_SCHEMA_VERSION)}
         for view, mtx in self.view_window_matrices.items():
-            matrices[f"{view}_window_matrix"] = mtx.array
+            matrices[f"view_{view}_window_matrix"] = mtx.array
         for sensor, mtx in self.sensor_window_matrices.items():
-            matrices[f"{sensor}_window_matrix"] = mtx.array
+            matrices[f"sensor_{sensor}_window_matrix"] = mtx.array
         for window, mtx in self.daylight_matrices.items():
             matrices[f"{window}_daylight_matrix"] = mtx.array
         for view, mtx in self.view_window_direct_matrices.items():
-            matrices[f"{view}_window_direct_matrix"] = mtx.array
+            matrices[f"view_{view}_window_direct_matrix"] = mtx.array
         for sensor, mtx in self.sensor_window_direct_matrices.items():
-            matrices[f"{sensor}_window_direct_matrix"] = mtx.array
+            matrices[f"sensor_{sensor}_window_direct_matrix"] = mtx.array
         for window, mtx in self.daylight_direct_matrices.items():
             matrices[f"{window}_daylight_direct_matrix"] = mtx.array
         for sensor, mtx in self.sensor_sun_direct_matrices.items():
-            matrices[f"{sensor}_sun_direct_matrix"] = mtx.array
+            matrices[f"sensor_{sensor}_sun_direct_matrix"] = mtx.array
         for view, mtx in self.view_sun_direct_matrices.items():
-            matrices[f"{view}_sun_direct_matrix"] = mtx.array
+            matrices[f"view_{view}_sun_direct_matrix"] = mtx.array
         for view, mtx in self.view_sun_direct_illuminance_matrices.items():
-            matrices[f"{view}_sun_direct_illuminance_matrix"] = mtx.array
+            matrices[f"view_{view}_sun_direct_illuminance_matrix"] = mtx.array
         np.savez_compressed(self.mfile, **matrices)
 
 

--- a/tests/test_matrix_cache.py
+++ b/tests/test_matrix_cache.py
@@ -1,0 +1,151 @@
+"""Regression tests for the matrix cache key collision (save/load_matrices).
+
+Legacy cache files keyed view, sensor, and surface matrices by bare entity
+name (e.g. '{name}_window_matrix' for views AND sensors). When a view and a
+sensor shared a name -- e.g. both named after the zone -- save_matrices
+silently overwrote one with the other and load_matrices restored a corrupted
+matrix without raising. These tests exercise the namespaced schema (v2)
+roundtrip for all three phase methods and the legacy-file handling.
+
+The tests bypass __init__ (which requires Radiance octree generation) and
+drive save_matrices/load_matrices directly on minimal instances.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+from frads.methods import (
+    FivePhaseMethod,
+    ThreePhaseMethod,
+    TwoPhaseMethod,
+    _matrix_cache_prefixes,
+)
+
+
+def _mtx(shape, fill):
+    return SimpleNamespace(array=np.full(shape, fill, dtype=np.float64))
+
+
+def _empty_like(matrices):
+    return {name: SimpleNamespace(array=None) for name in matrices}
+
+
+class TestMatrixCacheRoundtrip(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_two_phase_view_sensor_name_collision(self):
+        """View and sensor named identically survive a save/load roundtrip."""
+        m = TwoPhaseMethod.__new__(TwoPhaseMethod)
+        m.mtxdir = self.tmpdir
+        m.config = SimpleNamespace(hash_str="cache")
+        m.mfile = self.tmpdir / "cache.npz"
+        m.view_sky_matrices = {"zone": _mtx((16, 146, 3), 1.0)}
+        m.sensor_sky_matrices = {"zone": _mtx((4, 146, 3), 2.0)}
+        m.save_matrices()
+
+        m.view_sky_matrices = _empty_like(m.view_sky_matrices)
+        m.sensor_sky_matrices = _empty_like(m.sensor_sky_matrices)
+        m.load_matrices()
+        self.assertEqual(m.view_sky_matrices["zone"].array.shape, (16, 146, 3))
+        self.assertTrue((m.view_sky_matrices["zone"].array == 1.0).all())
+        self.assertEqual(m.sensor_sky_matrices["zone"].array.shape, (4, 146, 3))
+        self.assertTrue((m.sensor_sky_matrices["zone"].array == 2.0).all())
+
+    def test_three_phase_view_sensor_surface_name_collision(self):
+        """View, sensor, and surface with one shared name stay distinct."""
+        m = ThreePhaseMethod.__new__(ThreePhaseMethod)
+        m.mfile = self.tmpdir / "cache3.npz"
+        m.view_window_matrices = {"zone": _mtx((16, 145, 3), 1.0)}
+        m.sensor_window_matrices = {"zone": _mtx((4, 145, 3), 2.0)}
+        m.surface_window_matrices = {"zone": _mtx((9, 145, 3), 3.0)}
+        m.daylight_matrices = {"win1": _mtx((145, 146, 3), 4.0)}
+        m.save_matrices()
+
+        for attr in ("view_window_matrices", "sensor_window_matrices",
+                     "surface_window_matrices", "daylight_matrices"):
+            setattr(m, attr, _empty_like(getattr(m, attr)))
+        m.load_matrices()
+        self.assertEqual(m.view_window_matrices["zone"].array.shape, (16, 145, 3))
+        self.assertEqual(m.sensor_window_matrices["zone"].array.shape, (4, 145, 3))
+        self.assertEqual(m.surface_window_matrices["zone"].array.shape, (9, 145, 3))
+        self.assertEqual(m.daylight_matrices["win1"].array.shape, (145, 146, 3))
+
+    def test_five_phase_view_sensor_name_collision(self):
+        """FivePhase roundtrip with colliding names incl. direct/sun keys."""
+        m = FivePhaseMethod.__new__(FivePhaseMethod)
+        m.mfile = self.tmpdir / "cache5.npz"
+        m.view_window_matrices = {"zone": _mtx((16, 145, 3), 1.0)}
+        m.sensor_window_matrices = {"zone": _mtx((4, 145, 3), 2.0)}
+        m.daylight_matrices = {"win1": _mtx((145, 146, 3), 3.0)}
+        m.view_window_direct_matrices = {"zone": _mtx((16, 145, 3), 4.0)}
+        m.sensor_window_direct_matrices = {"zone": _mtx((4, 145, 3), 5.0)}
+        m.daylight_direct_matrices = {"win1": _mtx((145, 146, 3), 6.0)}
+        m.sensor_sun_direct_matrices = {"zone": _mtx((4, 5185, 3), 7.0)}
+        m.view_sun_direct_matrices = {"zone": _mtx((16, 5185, 3), 8.0)}
+        m.view_sun_direct_illuminance_matrices = {"zone": _mtx((16, 5185, 3), 9.0)}
+        m.save_matrices()
+
+        for attr in ("view_window_matrices", "sensor_window_matrices",
+                     "daylight_matrices", "view_window_direct_matrices",
+                     "sensor_window_direct_matrices", "daylight_direct_matrices",
+                     "sensor_sun_direct_matrices", "view_sun_direct_matrices",
+                     "view_sun_direct_illuminance_matrices"):
+            setattr(m, attr, _empty_like(getattr(m, attr)))
+        m.load_matrices()
+        self.assertEqual(m.view_window_matrices["zone"].array.shape, (16, 145, 3))
+        self.assertTrue((m.view_window_matrices["zone"].array == 1.0).all())
+        self.assertEqual(m.sensor_window_matrices["zone"].array.shape, (4, 145, 3))
+        self.assertEqual(m.sensor_sun_direct_matrices["zone"].array.shape, (4, 5185, 3))
+        self.assertTrue((m.view_sun_direct_matrices["zone"].array == 8.0).all())
+        self.assertTrue(
+            (m.view_sun_direct_illuminance_matrices["zone"].array == 9.0).all()
+        )
+
+    def test_legacy_cache_without_collision_loads(self):
+        """A v1 (un-namespaced) file with distinct names still loads."""
+        mfile = self.tmpdir / "legacy.npz"
+        np.savez(
+            mfile,
+            **{
+                "v1_sky_matrix": np.ones((16, 146, 3)),
+                "s1_sky_matrix": np.full((4, 146, 3), 2.0),
+            },
+        )
+        m = TwoPhaseMethod.__new__(TwoPhaseMethod)
+        m.mfile = mfile
+        m.view_sky_matrices = {"v1": SimpleNamespace(array=None)}
+        m.sensor_sky_matrices = {"s1": SimpleNamespace(array=None)}
+        m.load_matrices()
+        self.assertEqual(m.view_sky_matrices["v1"].array.shape, (16, 146, 3))
+        self.assertEqual(m.sensor_sky_matrices["s1"].array.shape, (4, 146, 3))
+
+    def test_legacy_cache_with_collision_raises(self):
+        """A v1 file whose view/sensor names collide is corrupted -> error."""
+        mfile = self.tmpdir / "legacy_bad.npz"
+        np.savez(mfile, **{"zone_sky_matrix": np.full((4, 146, 3), 2.0)})
+        m = TwoPhaseMethod.__new__(TwoPhaseMethod)
+        m.mfile = mfile
+        m.view_sky_matrices = {"zone": SimpleNamespace(array=None)}
+        m.sensor_sky_matrices = {"zone": SimpleNamespace(array=None)}
+        with self.assertRaises(ValueError):
+            m.load_matrices()
+
+    def test_prefix_helper_v2(self):
+        mdata = {"_schema_version": np.int64(2)}
+        self.assertEqual(
+            _matrix_cache_prefixes(mdata, Path("x.npz"), {"a"}, {"a"}),
+            ("view_", "sensor_", "surface_"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
save_matrices keyed all per-entity matrices by bare entity name:
'{name}_sky_matrix' (TwoPhase, views AND sensors), '{name}_window_matrix'
(ThreePhase: views, sensors AND surfaces; FivePhase: views and sensors) and
'{name}_sun_direct_matrix' (FivePhase). When two groups share a name -- e.g.
a view and a sensor both named after the zone -- the later group overwrote
the earlier one in the .npz, and load_matrices restored the wrong array into
the survivor without any error. Downstream this manifests as degenerate
view matrices and noise-floor DGP values with no exception.

Namespace the keys per group (view_/sensor_/surface_) and stamp the file
with '_schema_version' = 2. Legacy (v1) files remain loadable when their
entity names do not collide; a colliding legacy file now raises ValueError
with a pointer to regenerate, instead of silently returning corrupt data.

Adds tests: roundtrips with colliding names for all three phase methods
(shapes and contents preserved), legacy-file compatibility, and the
legacy-collision error path.
